### PR TITLE
Fix 24h conversion bug

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1584,10 +1584,11 @@ const MAXFRADirectorMVP = () => {
     
     const convertTo24h = (time12h) => {
       const [time, modifier] = time12h.split(' ');
-      let [hours, minutes] = time.split(':');
-      if (hours === '12') hours = '00';
-      if (modifier === 'PM') hours = parseInt(hours, 10) + 12;
-      return `${hours.padStart(2, '0')}:${minutes}`;
+      const [h, minutes] = time.split(':');
+      let hourNum = parseInt(h, 10);
+      if (hourNum === 12) hourNum = 0;
+      if (modifier === 'PM') hourNum += 12;
+      return `${hourNum.toString().padStart(2, '0')}:${minutes}`;
     };
     
     const timeStartMX = convertTo24h(timeStart);


### PR DESCRIPTION
## Summary
- fix incorrect 12h to 24h conversion when creating appointment confirmations

## Testing
- `npm run build`
- `npm run lint` *(fails: 53 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687ea8d71a54832ba7273538c6927d4e